### PR TITLE
Support Org Agenda file installation, fix mode definition

### DIFF
--- a/README.org
+++ b/README.org
@@ -9,14 +9,17 @@ installing git repositories as dependencies, and warning about missing required 
 
 To use the mode, create a file called PROJECT.yaml in the root of your project directory and
 add a Yaml object with the following properties:
-- required-resources: A list of resources that must exist for the project to be
+- ~required-resources~: A list of resources that must exist for the project to be
   considered complete.
-- deps: A list of git repositories to be cloned as dependencies.
-- local-files: A list of files to be copied from their current location to the
+- ~agenda-files~: A list of files to add to ~org-agenda-files~. As these are processed
+  *last*, installation only creates these files if they are not otherwise created. Any of
+  these already present are just added to ~org-agenda-files~.
+- ~deps~: A list of git repositories to be cloned as dependencies.
+- ~local-files~: A list of files to be copied from their current location to the
   project directory.
-- symlinks: List of link/target pairs to create as symlinks relative to the project
+- ~symlinks~: List of link/target pairs to create as symlinks relative to the project
   directory.
-- treemacs-workspaces: A list of Treemacs workspace names this project should be added to.
+- ~treemacs-workspaces~: A list of Treemacs workspace names this project should be added to.
 
 Note that any omitted ~dest~ or ~link~ field results in that resource's creation in the
 project root directory, named as the ~Filename.extension~.
@@ -25,6 +28,9 @@ This project prefers Yaml.
 #+begin_src yaml :tangle /tmp/PROJECT.yaml
 project-name: "Declarative Project Mode"
 root-dir: "/tmp/demo-project"
+agenda-files:
+  - README.org
+  - AGENDA.org
 required-resources:
   - README.org
 deps:
@@ -39,6 +45,8 @@ local-files:
     # (↑) path relative to project root dir
   - src: /path/to/src
     # (↑) default dest is project root dir
+  - src: /path/to/README.org
+    dest: README.org
 symlinks:
   - targ: /path/to/link-target
     link: path/to/symlink
@@ -74,6 +82,7 @@ conform to individual projects.
     - cloud storage backend
     - s3 backend
     - package managers
-- Improved startup/shutdown checks for workspaces
-- Destination specification to help consolidate project definitions
 - Recursive project definitions, i.e. subprojects
+- Optional param for any spec attribute
+    - specify files as optional, otherwise assume required
+    - deprecates ~required-resources~

--- a/README.org
+++ b/README.org
@@ -7,27 +7,32 @@ This mode allows you to define a project as a conceptual grouping of software co
 and then manage and install these components with ease. The mode currently supports
 installing git repositories as dependencies, and warning about missing required resources.
 
-To use the mode, create a file called PROJECT.yaml in the root of your project directory and
-add a Yaml object with the following properties:
-- ~required-resources~: A list of resources that must exist for the project to be
-  considered complete.
-- ~agenda-files~: A list of files to add to ~org-agenda-files~. As these are processed
+To use, enable the global ~declarative-project-mode~, and visit a Yaml file with the
+following properties. When visiting the file, trigger
+~declarative-project--install-project~ with the key-binding ~C-c C-c i~
+- ~name~ :: The display name for the project to treemacs, etc.
+- ~root-directory~ :: The directory into which all project dependencies are installed.
+  Paths specified in the yaml spec are relative to ~root-directory~ for any install
+  operations.
+- ~agenda-files~ :: A list of files to add to ~org-agenda-files~. As these are processed
   *last*, installation only creates these files if they are not otherwise created. Any of
   these already present are just added to ~org-agenda-files~.
-- ~deps~: A list of git repositories to be cloned as dependencies.
-- ~local-files~: A list of files to be copied from their current location to the
-  project directory.
-- ~symlinks~: List of link/target pairs to create as symlinks relative to the project
+- ~required-resources~ :: A list of resources that must exist for the project to be
+  considered complete.
+- ~deps~ :: A list of git repositories to be cloned as dependencies.
+- ~local-files~ :: A list of files to be copied from their current location to the project
   directory.
-- ~treemacs-workspaces~: A list of Treemacs workspace names this project should be added to.
+- ~symlinks~ :: List of link/target pairs to create as symlinks relative to the project
+  directory.
+- ~treemacs-workspaces~ :: A list of Treemacs workspace names this project should be added
+  to.
 
 Note that any omitted ~dest~ or ~link~ field results in that resource's creation in the
-project root directory, named as the ~Filename.extension~.
+project root directory, named as the specified source ~filename.extension~.
 
-This project prefers Yaml.
 #+begin_src yaml :tangle /tmp/PROJECT.yaml
-project-name: "Declarative Project Mode"
-root-dir: "/tmp/demo-project"
+name: "Declarative Project Mode"
+root-directory: "/tmp/demo-project"
 agenda-files:
   - README.org
   - AGENDA.org
@@ -56,17 +61,26 @@ treemacs-workspaces:
   - "Demos"
 #+end_src
 
-The mode can be activated by visiting a file in the project directory with the PROJECT.yaml
-file or by running (declarative-project-mode 1) in the project directory.
+The mode can be activated by visiting a file in the project directory with the
+PROJECT.yaml file or by running (declarative-project-mode 1) in the project directory.
 
 *Install the project* by running "C-c C-c i" from the ~PROJECT.yaml~ file.
 
 * Noteworthy Features
+** Decentralized Org Agenda Management
+Specifying ~agenda-files~ results in those files' addition to ~org-agenda-files~ upon
+project installation, and upon mode enablement. This mode caches the filepaths for any
+installed projects, and checks the spec files at the specified file paths for their agenda
+files. Any of them found are added to ~org-agenda-files~, and if
+~declarative-project--persist-agenda-files~ then missing agenda files are recreated.
+
+This allows users to specify any relevant agenda files as they define projects, and keep
+this list current without additional overhead.
+
 ** Treemacs Workspace Assignment
 Provided a list of treemacs workspaces, the installation process assigns this project to
-each specified worksace. This should help decentralize workspace configuration,
-helping construct conceptual groupings of projects regardless of their location in the
-filesystem.
+each specified worksace. This should help decentralize workspace configuration, helping
+construct conceptual groupings of projects regardless of their location in the filesystem.
 
 ** Locally Copy or Symlink Resources
 It's often useful to maintain documentation in a form of knowlegebase such as Org Roam.

--- a/README.org
+++ b/README.org
@@ -1,9 +1,9 @@
 * declarative-project-mode
 
-A minor mode for managing and installing a variety of project contents with a simple
+A global minor mode for managing and installing a variety of project contents with a simple
 declarative syntax in Emacs.
 
-This mode allows you to define a project as a conceptual grouping of software components,
+This global mode allows you to define a project as a conceptual grouping of software components,
 and then manage and install these components with ease. The mode currently supports
 installing git repositories as dependencies, and warning about missing required resources.
 

--- a/declarative-project-mode.el
+++ b/declarative-project-mode.el
@@ -288,7 +288,7 @@ Any missing files will be created if declarative-project--persist-agenda-files."
             (define-key map (kbd "C-c C-c i")
                         'declarative-project--install-project)
             map)
-  :after-hook #'declarative-project--mode-setup)
+  (declarative-project--mode-setup))
 
 (provide 'declarative-project-mode)
 ;;; declarative-project-mode.el ends here

--- a/declarative-project-mode.el
+++ b/declarative-project-mode.el
@@ -264,11 +264,12 @@ Any missing files will be created if declarative-project--persist-agenda-files."
     (declarative-project--create-symlinks project)
     (declarative-project--apply-treemacs-workspaces project)
     (declarative-project--append-to-cache project-file)
+    (declarative-project--rebuild-org-agenda)
     (message "...Finished Installation!")))
 
 (defun declarative-project--mode-setup ()
   "Load in cache, prune and handle agenda files."
-  (when (not (or declarative-project-mode global-declarative-project-mode))
+  (when (not declarative-project-mode)
         (message "Declarative Project Mode Enabled!")
         (setq declarative-project--cached-projects (declarative-project--read-cache))
         (when declarative-project--auto-prune-cache
@@ -282,6 +283,7 @@ Any missing files will be created if declarative-project--persist-agenda-files."
   :lighter " DPM"
   :init-value nil
   :global t
+  :group 'minor-modes
   :keymap (let ((map (make-sparse-keymap)))
             (define-key map (kbd "C-c C-c i")
                         'declarative-project--install-project)

--- a/declarative-project-mode.el
+++ b/declarative-project-mode.el
@@ -266,6 +266,7 @@ Any missing files will be created if declarative-project--persist-agenda-files."
     (declarative-project--append-to-cache project-file)
     (message "...Finished Installation!")))
 
+;;;###autoload
 (define-minor-mode declarative-project-mode
   "Declarative Project mode."
   :lighter " DPM"
@@ -281,6 +282,9 @@ Any missing files will be created if declarative-project--persist-agenda-files."
           (message "WARNING :: Pruned the following projects from cache:\n%s"
                 (mapconcat 'identity (declarative-project--prune-cache) "\n\t")))
         (declarative-project--rebuild-org-agenda))))
+
+;;;###autoload
+(define-globalized-minor-mode global-declarative-project-mode declarative-project-mode declarative-project-mode :group declarative-project-mode)
 
 (add-hook 'find-file-hook (lambda ()
                             (when (string-match-p "/PROJECT.yaml$" (buffer-file-name))

--- a/declarative-project-mode.el
+++ b/declarative-project-mode.el
@@ -277,7 +277,7 @@ Any missing files will be created if declarative-project--persist-agenda-files."
   (if declarative-project-mode
       (progn
         (message "Declarative Project Mode Enabled!")
-        (declarative-project--read-cache)
+        (setq declarative-project--cached-projects (declarative-project--read-cache))
         (when declarative-project--auto-prune-cache
           (message "WARNING :: Pruned the following projects from cache:\n%s"
                 (mapconcat 'identity (declarative-project--prune-cache) "\n\t")))

--- a/declarative-project-mode.el
+++ b/declarative-project-mode.el
@@ -269,7 +269,7 @@ Any missing files will be created if declarative-project--persist-agenda-files."
 (defun declarative-project--mode-setup ()
   "Load in cache, prune and handle agenda files."
   (message "Declarative Project Mode Enabled!")
-  (declarative-project--read-cache)
+  (setq declarative-project--cached-projects (declarative-project--read-cache))
   (when declarative-project--auto-prune-cache
     (message "WARNING :: Pruned the following projects from cache:\n%s"
              (mapconcat 'identity (declarative-project--prune-cache) "\n\t")))
@@ -290,13 +290,7 @@ Any missing files will be created if declarative-project--persist-agenda-files."
                         'declarative-project--install-project)
             map)
   (if (or declarative-project-mode global-declarative-project-mode)
-      (progn
-        (message "Declarative Project Mode Enabled!")
-        (setq declarative-project--cached-projects (declarative-project--read-cache))
-        (when declarative-project--auto-prune-cache
-          (message "WARNING :: Pruned the following projects from cache:\n%s"
-                   (mapconcat 'identity (declarative-project--prune-cache) "\n\t")))
-        (declarative-project--rebuild-org-agenda))))
+      (declarative-project--mode-setup)))
 
 (add-hook 'find-file-hook (lambda ()
                             (when (string-match-p "/PROJECT.yaml$" (buffer-file-name))

--- a/declarative-project-mode.el
+++ b/declarative-project-mode.el
@@ -266,6 +266,21 @@ Any missing files will be created if declarative-project--persist-agenda-files."
     (declarative-project--append-to-cache project-file)
     (message "...Finished Installation!")))
 
+(defun declarative-project--mode-setup ()
+  "Load in cache, prune and handle agenda files."
+  (message "Declarative Project Mode Enabled!")
+  (declarative-project--read-cache)
+  (when declarative-project--auto-prune-cache
+    (message "WARNING :: Pruned the following projects from cache:\n%s"
+             (mapconcat 'identity (declarative-project--prune-cache) "\n\t")))
+  (declarative-project--rebuild-org-agenda))
+
+;;;###autoload
+(define-globalized-minor-mode global-declarative-project-mode
+  declarative-project-mode
+  declarative-project--mode-setup
+  :group 'declarative-project-mode)
+
 ;;;###autoload
 (define-minor-mode declarative-project-mode
   "Declarative Project mode."
@@ -280,11 +295,8 @@ Any missing files will be created if declarative-project--persist-agenda-files."
         (setq declarative-project--cached-projects (declarative-project--read-cache))
         (when declarative-project--auto-prune-cache
           (message "WARNING :: Pruned the following projects from cache:\n%s"
-                (mapconcat 'identity (declarative-project--prune-cache) "\n\t")))
+                   (mapconcat 'identity (declarative-project--prune-cache) "\n\t")))
         (declarative-project--rebuild-org-agenda))))
-
-;;;###autoload
-(define-globalized-minor-mode global-declarative-project-mode declarative-project-mode declarative-project-mode :group declarative-project-mode)
 
 (add-hook 'find-file-hook (lambda ()
                             (when (string-match-p "/PROJECT.yaml$" (buffer-file-name))

--- a/declarative-project-mode.el
+++ b/declarative-project-mode.el
@@ -274,7 +274,7 @@ Any missing files will be created if declarative-project--persist-agenda-files."
             (define-key map (kbd "C-c C-c i")
                         'declarative-project--install-project)
             map)
-  (if declarative-project-mode
+  (if (or declarative-project-mode global-declarative-project-mode)
       (progn
         (message "Declarative Project Mode Enabled!")
         (setq declarative-project--cached-projects (declarative-project--read-cache))

--- a/declarative-project-mode.el
+++ b/declarative-project-mode.el
@@ -269,7 +269,7 @@ Any missing files will be created if declarative-project--persist-agenda-files."
 
 (defun declarative-project--mode-setup ()
   "Load in cache, prune and handle agenda files."
-  (when (not declarative-project-mode)
+  (when declarative-project-mode
         (message "Declarative Project Mode Enabled!")
         (setq declarative-project--cached-projects (declarative-project--read-cache))
         (when declarative-project--auto-prune-cache
@@ -280,8 +280,8 @@ Any missing files will be created if declarative-project--persist-agenda-files."
 ;;;###autoload
 (define-minor-mode declarative-project-mode
   "Declarative Project mode."
+  nil
   :lighter " DPM"
-  :init-value nil
   :global t
   :group 'minor-modes
   :keymap (let ((map (make-sparse-keymap)))

--- a/declarative-project-mode.el
+++ b/declarative-project-mode.el
@@ -277,20 +277,16 @@ Any missing files will be created if declarative-project--persist-agenda-files."
         (declarative-project--rebuild-org-agenda)))
 
 ;;;###autoload
-(define-globalized-minor-mode global-declarative-project-mode
-  declarative-project-mode
-  declarative-project--mode-setup
-  :group 'declarative-project-mode)
-
-;;;###autoload
 (define-minor-mode declarative-project-mode
   "Declarative Project mode."
   :lighter " DPM"
-  :default nil
+  :init-value nil
+  :global t
   :keymap (let ((map (make-sparse-keymap)))
             (define-key map (kbd "C-c C-c i")
                         'declarative-project--install-project)
-            map))
+            map)
+  :after-hook #'declarative-project--mode-setup)
 
 (provide 'declarative-project-mode)
 ;;; declarative-project-mode.el ends here

--- a/declarative-project-mode.el
+++ b/declarative-project-mode.el
@@ -268,12 +268,13 @@ Any missing files will be created if declarative-project--persist-agenda-files."
 
 (defun declarative-project--mode-setup ()
   "Load in cache, prune and handle agenda files."
-  (message "Declarative Project Mode Enabled!")
-  (setq declarative-project--cached-projects (declarative-project--read-cache))
-  (when declarative-project--auto-prune-cache
-    (message "WARNING :: Pruned the following projects from cache:\n%s"
-             (mapconcat 'identity (declarative-project--prune-cache) "\n\t")))
-  (declarative-project--rebuild-org-agenda))
+  (when (not declarative-project-mode)
+        (message "Declarative Project Mode Enabled!")
+        (setq declarative-project--cached-projects (declarative-project--read-cache))
+        (when declarative-project--auto-prune-cache
+        (message "WARNING :: Pruned the following projects from cache:\n%s"
+                (mapconcat 'identity (declarative-project--prune-cache) "\n\t")))
+        (declarative-project--rebuild-org-agenda)))
 
 ;;;###autoload
 (define-globalized-minor-mode global-declarative-project-mode
@@ -285,12 +286,11 @@ Any missing files will be created if declarative-project--persist-agenda-files."
 (define-minor-mode declarative-project-mode
   "Declarative Project mode."
   :lighter " DPM"
+  :default nil
   :keymap (let ((map (make-sparse-keymap)))
             (define-key map (kbd "C-c C-c i")
                         'declarative-project--install-project)
-            map)
-  (if (or declarative-project-mode global-declarative-project-mode)
-      (declarative-project--mode-setup)))
+            map))
 
 (provide 'declarative-project-mode)
 ;;; declarative-project-mode.el ends here

--- a/declarative-project-mode.el
+++ b/declarative-project-mode.el
@@ -292,8 +292,5 @@ Any missing files will be created if declarative-project--persist-agenda-files."
   (if (or declarative-project-mode global-declarative-project-mode)
       (declarative-project--mode-setup)))
 
-(add-hook 'find-file-hook (lambda ()
-                            (when (string-match-p "/PROJECT.yaml$" (buffer-file-name))
-                              (declarative-project-mode 1))))
 (provide 'declarative-project-mode)
 ;;; declarative-project-mode.el ends here

--- a/declarative-project-mode.el
+++ b/declarative-project-mode.el
@@ -268,7 +268,7 @@ Any missing files will be created if declarative-project--persist-agenda-files."
 
 (defun declarative-project--mode-setup ()
   "Load in cache, prune and handle agenda files."
-  (when (not declarative-project-mode)
+  (when (not (or declarative-project-mode global-declarative-project-mode))
         (message "Declarative Project Mode Enabled!")
         (setq declarative-project--cached-projects (declarative-project--read-cache))
         (when declarative-project--auto-prune-cache


### PR DESCRIPTION
Create a centralized org-agenda file cache rebuilt with mode setup, and fix mode initialization behavior.

## Detailed Summary of changes
Created a cache of PROJECT.yaml file paths checked when the mode is enabled. During mode setup these files are checked for any specified agenda files. Files found to exist are added to `org-agenda-files`, while missing files are recreated when `declarative-project--persist-agenda-files` and subsequently added to `org-agenda-files`.

Additionally the mode definition has been cleaned up & simplified. This is now a global mode as most behavior is based around installation & management of project resources defined around the file system in yaml files. 

Decentralized configuration of `org-agenda-files` should improve usability of this mode, as users can now create these adhoc, without visiting user configuration files. Further, the persistent nature of these cached project definitions means the `org-agenda-files` variable should remain accurate with little-to-no additional overhead for user configuration; just enable the minor mode at startup!