### PR TITLE
Bugfixes, cache link format update

### DIFF
--- a/README.org
+++ b/README.org
@@ -17,6 +17,15 @@ Currently supported behavior:
 There are two supported specification formats: a YAML spec file, or the same YAML
 specification within an org mode source block.
 
+** Emacs Configuration Changes
+With the ~use-package!~ macro:
+#+begin_src elisp
+(use-package! declarative-project-mode
+  :after org
+  :init
+  (declarative-project--mode-setup))
+#+end_src
+
 ** Plain YAML
 To install and manage a project in plain YAML:
 1. Follow ~Defining a Project~ to create the YAML spec file

--- a/README.org
+++ b/README.org
@@ -23,6 +23,10 @@ With the ~use-package!~ macro:
 (use-package! declarative-project-mode
   :after org
   :init
+  ;; Optionally enable auto-prune to remove invalid projects without prompt when:
+  ;; - Initializing the mode's setup
+  ;; - Installing a new project
+  (setq declarative-project--auto-prune-cache t) ;; default value is `nil'
   (declarative-project--mode-setup))
 #+end_src
 

--- a/declarative-project-mode.el
+++ b/declarative-project-mode.el
@@ -446,12 +446,13 @@ Any missing files will be created if declarative-project--persist-agenda-files."
   (let ((source-file (or source-file
                          (buffer-file-name))))
     (declarative-project--install-project
-     )
+     (declarative-project--read-project-from-file source-file))))
 
-         (defun declarative-project--install-project (&optional project source-file)
-            "Step step through project spec & apply any blocks found."
-            (interactive)
-            (let* ((source-file (or source-file (expand-file-name "PROJECT.yaml" default-directory)))
+
+(defun declarative-project--install-project (&optional project source-file)
+  "Step step through project spec & apply any blocks found."
+  (interactive)
+  (let* ((source-file (or source-file (expand-file-name "PROJECT.yaml" default-directory)))
          (project (or project
                       (declarative-project--read-project-from-file source-file)
                       (declarative-project--read-project-from-file (expand-file-name (buffer-file-name (current-buffer)))))))
@@ -469,9 +470,9 @@ Any missing files will be created if declarative-project--persist-agenda-files."
     (message "...Finished Installation!")
     project))
 
-         (defun declarative-project--mode-setup ()
-            "Load in cache, prune and handle agenda files."
-            (when declarative-project-mode
+(defun declarative-project--mode-setup ()
+  "Load in cache, prune and handle agenda files."
+  (when declarative-project-mode
     (message "Declarative Project Mode Enabled!")
     (setq declarative-project--cached-projects (declarative-project--read-cache))
     (warn "Found these projects boss:\n%s" declarative-project--cached-projects)
@@ -481,13 +482,13 @@ Any missing files will be created if declarative-project--persist-agenda-files."
     (declarative-project--rebuild-org-agenda)))
 
 ;;;###autoload
-         (define-derived-mode declarative-project-mode yaml-mode
-            "Declarative Project mode."
-            :init-value nil
-            :lighter " DPM"
-            :global t
-            :group 'minor-modes
-            (declarative-project--mode-setup))
+(define-derived-mode declarative-project-mode yaml-mode
+  "Declarative Project mode."
+  :init-value nil
+  :lighter " DPM"
+  :global t
+  :group 'minor-modes
+  (declarative-project--mode-setup))
 
-         (provide 'declarative-project-mode)
+(provide 'declarative-project-mode)
 ;;; declarative-project-mode.el ends here

--- a/declarative-project-mode.el
+++ b/declarative-project-mode.el
@@ -396,7 +396,7 @@ Any missing files will be created if declarative-project--persist-agenda-files."
          (match-groups (declarative-project--source-linkp source-link))
          (path (alist-get :path match-groups))
          (begin (alist-get :begin match-groups)))
-    (when (and (stringp path) (numberp begin))
+    (when (and (file-readable-p path) (numberp begin))
     (save-excursion
       (with-temp-buffer
         (insert-file-contents path nil)

--- a/declarative-project-mode.el
+++ b/declarative-project-mode.el
@@ -5,8 +5,7 @@
 ;; Author: Hayden Stanko <hayden@cuttle.codes>
 ;; Maintainer: Hayden Stanko <hayden@cuttle.codes>
 ;; Created: January 13, 2023
-;; Modified: May 11, 2023
-;; Version: 0.0.6
+;; Version: 0.0.7
 ;; Keywords: project management, dependency management, declarative syntax, emacs minor-mode.
 ;; Homepage: https://github.com/cuttlefisch/declarative-project-mode
 ;; Package-Requires: ((emacs "27.1") (ghub "3.5.1") (treemacs "2.10") (yaml-mode "0.0.15") (yaml "0.5.1"))
@@ -26,11 +25,7 @@
 ;;
 ;;; Commentary:
 ;;
-;; Declarative Project mode is a minor mode for managing project resources. The
-;; mode is triggered by visiting a directory containing a PROJECT.yaml file. The
-;; PROJECT.yaml file should be in yaml format and may contain the following
-;; fields "name", "required-resources", "agenda-files", "deps", "local-files",
-;; "symlinks", "treemacs-workspaces".
+;; Declarative Project mode is a minor mode for managing project resources.
 ;;
 ;; Projects are cached in user-emacs-directory. The cache updates org agenda
 ;; with any declared agenda files from the cache upon startup. Users can

--- a/declarative-project-mode.el
+++ b/declarative-project-mode.el
@@ -367,15 +367,18 @@ Any missing files will be created if declarative-project--persist-agenda-files."
                             (message "checking project at:\t%s" source-link)
                             (or (let* ((match-groups (declarative-project--source-linkp source-link))
                                        (path (alist-get :path match-groups))
-                                       (begin (alist-get :begin match-groups)))
+                                       (begin (alist-get :begin match-groups))
+                                       (found-org-element (declarative-project--org-element-at-source-link source-link)))
                                   ;; To remain in the cache
                                   ;;   - :path must be valid string
                                   ;;   - File must exist at :path
                                   ;;   - SOURCE-LINK :begin matches the begin property of the org-element
+                                  ;;   - Org element at SOURCE-LINK is a src-block
                                   ;;   - Source block at SOURCE-LINK must containvalid project
                                   (and (stringp path)
                                        (file-readable-p path)
-                                       (equal begin (org-element-property :begin (declarative-project--org-element-at-source-link source-link)))
+                                       (string= "src-block" (car found-org-element))
+                                       (equal begin (org-element-property :begin found-org-element))
                                        (declarative-project-p
                                         (declarative-project--project-from-source-link source-link))))
                                 ;; In this case source-link /should/ represent a file-path
@@ -488,6 +491,8 @@ Any missing files will be created if declarative-project--persist-agenda-files."
     (declarative-project--copy-local-files project)
     (declarative-project--create-symlinks project)
     (declarative-project--append-to-cache (declarative-project-source-link project))
+    (when declarative-project--auto-prune-cache
+      (declarative-project--prune-cache))
     (declarative-project--refresh-cache-from-file)
     (declarative-project--check-required-resources project)
     (declarative-project--rebuild-org-agenda)


### PR DESCRIPTION
Changes focus on fixing previously marked bugs, mostly regarding caching behavior. 

The cache link format no longer holds an `:end` field as the `:begin` and `:path` define the start of an org mode block, from which the `:end` can be derived.  This simplifies tracking unique cache entries substantially.

