### PR TITLE
Fix install-from-content failing when root-directory doesn't exist

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,6 +1,20 @@
 #+title: Changelog
 #+author: Hayden Stanko
 
+* 0.3.4 — 2026-04-14
+
+** Bug fixes
+- Fix =--install-from-content= failing when =root-directory= doesn't exist ::
+  =call-process= requires =default-directory= to be a valid path.  When
+  =root-directory= in the spec pointed to a not-yet-cloned directory, the
+  install pipeline crashed with "No such file or directory".  Now
+  =(make-directory default-directory t)= is called before the pipeline runs.
+
+** Tests
+- 1 new spec: non-existent =root-directory= is created before pipeline
+  stages execute.
+- Total spec count: 105 (up from 104 in 0.3.3).
+
 * 0.3.3 — 2026-03-21
 
 ** Bug fixes

--- a/declarative-project-mode.el
+++ b/declarative-project-mode.el
@@ -6,7 +6,7 @@
 ;; Maintainer: Hayden Stanko <system.cuttle@gmail.com>
 ;; Created: January 13, 2023
 ;; Modified: March 21, 2026
-;; Version: 0.3.3
+;; Version: 0.3.4
 ;; Keywords: convenience, tools, project
 ;; Homepage: https://github.com/cuttlefisch/declarative-project-mode
 ;; Package-Requires: ((emacs "28.1") (yaml "0.5.1"))

--- a/declarative-project-mode.el
+++ b/declarative-project-mode.el
@@ -215,6 +215,7 @@ EXTRA-KEYS is an alist of additional keys to set in the resource hash."
                            (file-name-as-directory (expand-file-name rd))))
          (default-directory (or root-from-spec
                                 (file-name-as-directory (expand-file-name project-dir)))))
+    (make-directory default-directory t)
     (puthash 'project-root default-directory project-resources)
     (dolist (pair extra-keys)
       (puthash (car pair) (cdr pair) project-resources))

--- a/declarative-project-treemacs.el
+++ b/declarative-project-treemacs.el
@@ -6,7 +6,7 @@
 ;; Maintainer: Hayden Stanko <system.cuttle@gmail.com>
 ;; Created: January 14, 2023
 ;; Modified: March 21, 2026
-;; Version: 0.3.3
+;; Version: 0.3.4
 ;; Keywords: convenience, tools, project
 ;; Homepage: https://github.com/cuttlefisch/declarative-project-mode
 ;; Package-Requires: ((emacs "28.1") (treemacs "2.10") (declarative-project-mode "0.3.3"))

--- a/ob-declarative-project.el
+++ b/ob-declarative-project.el
@@ -6,7 +6,7 @@
 ;; Maintainer: Hayden Stanko <system.cuttle@gmail.com>
 ;; Created: March 15, 2026
 ;; Modified: March 21, 2026
-;; Version: 0.3.3
+;; Version: 0.3.4
 ;; Keywords: convenience, tools, project
 ;; Homepage: https://github.com/cuttlefisch/declarative-project-mode
 ;; Package-Requires: ((emacs "28.1") (org "9.0") (declarative-project-mode "0.3.3"))

--- a/test/test-declarative-project.el
+++ b/test/test-declarative-project.el
@@ -299,7 +299,25 @@
                 (expect (gethash 'project-root result)
                         :to-equal (file-name-as-directory
                                    (expand-file-name root-dir)))))
-          (delete-directory root-dir t))))))
+          (delete-directory root-dir t)))))
+
+  (it "creates non-existent root-directory before running pipeline"
+    (with-temp-project-dir
+      (let* ((novel-root (concat (make-temp-file "dpm-novel-" t) "/subdir")))
+        (unwind-protect
+            (progn
+              (spy-on 'declarative-project--check-required-resources)
+              (spy-on 'declarative-project--install-project-dependencies)
+              (spy-on 'declarative-project--copy-local-files)
+              (spy-on 'declarative-project--create-symlinks)
+              (spy-on 'declarative-project--apply-treemacs-workspaces)
+              (let* ((yaml (format "name: Test\nroot-directory: %s\n" novel-root))
+                     (result (declarative-project--install-from-content
+                              yaml project-dir)))
+                (expect (gethash 'project-root result)
+                        :to-equal (file-name-as-directory
+                                   (expand-file-name novel-root)))))
+          (delete-directory (file-name-directory novel-root) t))))))
 
 ;;; ==========================================================================
 ;;; declarative-project--install-project (parsing)


### PR DESCRIPTION
## Summary
- `--install-from-content` crashes with "No such file or directory" when the spec's `root-directory` points to a path that hasn't been created yet (e.g. a not-yet-cloned repo directory)
- Add `(make-directory default-directory t)` before the install pipeline runs, so the CWD is guaranteed to exist
- Add test: non-existent `root-directory` is created before pipeline stages execute

## Test plan
- [x] `make test` — all 105 specs pass
- [x] In Emacs, eval updated code, then `C-c C-c` on a src block whose `root-directory` doesn't exist yet — should clone successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)